### PR TITLE
Use later API for querying vertices

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -39,23 +39,47 @@ JSON Rules file explained (rules.json):
 {
   "rules": [              <- Json Array for rules. Rules are executed sequentially.>
     {
-      "name":"<mandatory - just a description and identifier for the rule. Not used by application>",
-      "lucene_query": "<mandatory - filtering vertex list with Lucene syntax (https://lucene.apache.org/core/4_7_0/queryparser/org/apache/lucene/queryparser/classic/package-summary.html)>",
-      "regex":[{           <- optional - if needed capture substring from vertex attribute with regex expression >
-        "attribute":"agent",
-        "expression":"(.*)-agent-(.*)$"
-      },
-      { "attribute":"hostname", "expression": "(.*) }
+      "name": "<mandatory - just a description and identifier for the rule. Not used by application>",
+      "query": { .... },  <- mandatory - filtering vertex list with APM query syntax syntax (https://docops.ca.com/ca-apm/10-7/en/api-reference/apm-rest-api/graph-vertex) >
+      "regex": [
+        {
+          "attribute": "agent",
+          "expression": "(.*)-agent-(.*)$"
+        },
+        {
+          "attribute": "hostname",
+          "expression": "(.*)"
+        }
       ],
       "attributes": {                           <- mandatory - define attributes to be updated with this rule. >
         "applicationServer": "jvm-{0}",         <- you can replace variable {0} with the first match in regex >
         "applicationPlatform": "platform-{1}",  <- you can replace variable {1} with the second match in regex >
         "customHostname": "{2}"                 <  if the attribute value is set to null (without quotes), the 
-      }                                            attributed is deleted from ATC >                      
-    },                                                         
+      }                                            attributed is deleted from ATC >    
+    },
     {
-      "name":"second rule as an example",
-      "lucene_query":"(attributes.agentDomain:SuperDomain/testDomain AND attributes.agent:/.*test.*/)",
+      "name": "second rule as an example",
+      "query": {
+        "includeStartPoint": false,
+        "orItems":[
+          {
+            "andItems":[
+              {
+                "itemType" : "attributeFilter",
+                "attributeName": "agentDomain",
+                "attributeOperator": "IN",
+                "values": [ "SuperDomain/testDomain" ]
+              },
+              {
+                "itemType" : "attributeFilter",
+                "attributeName": "agent",
+                "attributeOperator": "MATCHES",
+                "values": [ ".*test.*" ]
+              }
+            ]
+          }
+        ]
+      },
       "attributes": {
         "exampleAttribute": "exampleValue"
       }

--- a/rules.json.example
+++ b/rules.json.example
@@ -1,11 +1,32 @@
 {
   "rules": [
     {
-      "name":"first rule as an example",
-      "lucene_query": "attributes.agent:/.*-agent-.*/",
-      "regex":[
-        { "attribute":"agent", "expression":"(.*)-agent-(.*)$" },
-        { "attribute":"hostname", "expression":"(.*)" }
+      "name": "first rule as an example",
+      "query": {
+        "orItems": [
+          {
+            "andItems": [
+              {
+                "itemType": "attributeFilter",
+                "attributeName": "agent",
+                "attributeOperator": "MATCHES",
+                "values": [
+                  ".*-agent-.*"
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "regex": [
+        {
+          "attribute": "agent",
+          "expression": "(.*)-agent-(.*)$"
+        },
+        {
+          "attribute": "hostname",
+          "expression": "(.*)"
+        }
       ],
       "attributes": {
         "applicationServer": "jvm-{0}",
@@ -14,8 +35,28 @@
       }
     },
     {
-      "name":"second rule as an example",
-      "lucene_query":"(attributes.agentDomain:SuperDomain/testDomain AND attributes.agent:/.*test.*/)",
+      "name": "second rule as an example",
+      "query": {
+        "includeStartPoint": false,
+        "orItems":[
+          {
+            "andItems":[
+              {
+                "itemType" : "attributeFilter",
+                "attributeName": "agentDomain",
+                "attributeOperator": "IN",
+                "values": [ "SuperDomain/testDomain" ]
+              },
+              {
+                "itemType" : "attributeFilter",
+                "attributeName": "agent",
+                "attributeOperator": "MATCHES",
+                "values": [ ".*test.*" ]
+              }
+            ]
+          }
+        ]
+      },
       "attributes": {
         "exampleAttribute": "exampleValue"
       }


### PR DESCRIPTION
Thank you very much for this script I like it a lot.

Here is a change that is using later API for querying vertices. It is more flexible from topological query perspective, but also supports more complex deployments using ETC (cluster of clusters). It is supported from 10.5 and later.